### PR TITLE
Include full gallery images in <enclosure>

### DIFF
--- a/inc/tst-yandex-feed-core.php
+++ b/inc/tst-yandex-feed-core.php
@@ -244,6 +244,19 @@ Allow: /yandex/news/
 			$enclosure = $matches[4];
 		}
 		
+		$post_galleries = get_post_galleries( $post, false );
+		if ( count( $post_galleries ) ) {
+			foreach ( $post_galleries as $post_gallery ) {
+				$ids = explode( ',', $post_gallery['ids'] );
+				foreach ( $ids as $attachment_id ) {
+					$image_info   = wp_get_attachment_image_src( $attachment_id, 'full' );
+					$enclosure[] = $image_info[0];
+				}
+			}
+		}
+
+		$enclosure = array_unique($enclosure);
+		
 		if(empty($enclosure))
 			return $enclosure;
 				


### PR DESCRIPTION
При добавлении галереи в текст поста, в качестве изобажений используются превьюшки, обернутые в ссылку на полное изображение. В тэг `<enclosure>` попадают только превьюшки, которые слишком маленького размера для Яндекса. 

Мой код собирает все изображения из галерей поста в массив `$enclosure` в нормальном размере (full). Может быть, стоит вынести размер изображений, котрые должны подтягиваться в RSS в настройки плагина.
